### PR TITLE
(#4) initial support for cheats

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,37 @@ Some historical points in time are kept:
  * Incorporate `github.com/alecthomas/units` and `github.com/alecthomas/template` as local packages
  * Changes to make `staticcheck` happy
  * A new default template that shortens the help on large apps, old default preserved as `KingpinDefaultUsageTemplate`
+
+## Cheats
+
+I really like [cheat](https://github.com/cheat/cheat), a great little tool that gives access to bite-sized hints on what's great about a CLI tool.
+
+Fisk supports cheats natively, you can get cheat formatted hints right from the app with no extra dependencies or export cheats into the `cheat` app for use via its interface and integrations.
+
+```nohighlight
+$ nats cheat pub
+# To publish 100 messages with a random body between 100 and 1000 characters
+nats pub destination.subject "{{ Random 100 1000 }}" -H Count:{{ Count }} --count 100
+```
+
+Let's look how that is done:
+
+```go
+// WithCheats() enables cheats without adding any to the top, you
+// can also just call Cheat() at the top to both set a cheat and enable it
+// once enabled at the top all cheats in all sub commands are accessible
+nats := fisk.New("nats", "NATS Utility").WithCheats()
+
+pub := nats.Command("pub", "Publish utility")
+pub.Cheat(`# To publish 100 messages with a random.....`)
+```
+
+After that your app will have a new command `cheat` that gives access to the cheats. It will show
+a list of cheats when trying to access a command without cheats or when running `nats cheat --list`.
+
+```nohighlight
+$ nats cheat unknown
+Available Cheats:
+
+  nats/pub
+```

--- a/cmd.go
+++ b/cmd.go
@@ -229,6 +229,7 @@ type CmdClause struct {
 	aliases        []string
 	help           string
 	helpLong       string
+	cheat          string
 	isDefault      bool
 	validator      CmdClauseValidator
 	hidden         bool
@@ -247,7 +248,13 @@ func newCommand(app *Application, name, help string) *CmdClause {
 	return c
 }
 
-// Add an Alias for this command.
+// Cheat sets the cheat text to associate with this command
+func (c *CmdClause) Cheat(cheat string) *CmdClause {
+	c.cheat = cheat
+	return c
+}
+
+// Alias add an Alias for this command.
 func (c *CmdClause) Alias(name string) *CmdClause {
 	c.aliases = append(c.aliases, name)
 	return c
@@ -323,4 +330,27 @@ func (c *CmdClause) Hidden() *CmdClause {
 func (c *CmdClause) HelpLong(help string) *CmdClause {
 	c.helpLong = help
 	return c
+}
+
+func (c *CmdClause) cheatCommands() (res []string) {
+	if c.cheat != "" {
+		res = append(res, c.name)
+	}
+
+	for _, sc := range c.commands {
+		if sc.name == "cheat" {
+			continue
+		}
+
+		if sc.cheat != "" {
+			res = append(res, fmt.Sprintf("%s/%s", c.name, sc.name))
+		}
+
+		if len(sc.commands) > 0 {
+			res = append(res, sc.cheatCommands()...)
+		}
+	}
+
+	return res
+
 }

--- a/model.go
+++ b/model.go
@@ -166,6 +166,7 @@ type CmdModel struct {
 	Aliases     []string
 	Help        string
 	HelpLong    string
+	Cheat       string
 	FullCommand string
 	Depth       int
 	Hidden      bool
@@ -182,6 +183,7 @@ func (c *CmdModel) String() string {
 type ApplicationModel struct {
 	Name    string
 	Help    string
+	Cheat   string
 	Version string
 	Author  string
 	*ArgGroupModel
@@ -193,6 +195,7 @@ func (a *Application) Model() *ApplicationModel {
 	return &ApplicationModel{
 		Name:           a.Name,
 		Help:           a.Help,
+		Cheat:          a.cheat,
 		Version:        a.version,
 		Author:         a.author,
 		FlagGroupModel: a.flagGroup.Model(),
@@ -262,6 +265,7 @@ func (c *CmdClause) Model() *CmdModel {
 		Aliases:        c.aliases,
 		Help:           c.help,
 		HelpLong:       c.helpLong,
+		Cheat:          c.cheat,
 		Depth:          depth,
 		Hidden:         c.hidden,
 		Default:        c.isDefault,

--- a/templates.go
+++ b/templates.go
@@ -71,6 +71,38 @@ Commands:
 {{end}}\
 `
 
+// CheatTemplate renders cheat format help for an app
+var CheatTemplate = `{{if .Context.SelectedCommand }}\
+{{if .Context.SelectedCommand.Cheat }}\
+{{ .Context.SelectedCommand.Cheat }}
+{{else}}\
+{{if gt (CheatCommands | Count) 0}}\
+Available Cheats:
+
+{{ range CheatCommands }}\
+   {{.}}
+{{end}}\
+{{else}}\
+No cheats defined
+{{end}}\
+{{end}}\
+{{else}}\
+{{ if .App.Cheat }}\
+{{.App.Cheat}}
+{{else}}\
+{{if gt (CheatCommands | Count) 0}}\
+Available Cheats:
+
+{{ range CheatCommands }}\
+   {{.}}
+{{end}}\
+{{else}}\
+No cheats defined
+{{end}}\
+{{end}}\
+{{end}}\
+`
+
 // KingpinDefaultUsageTemplate is the default usage template as used by kingpin
 var KingpinDefaultUsageTemplate = `{{define "FormatCommand"}}\
 {{if .FlagSummary}} {{.FlagSummary}}{{end}}\
@@ -118,7 +150,7 @@ Commands:
 {{end}}\
 `
 
-// Usage template where command's optional flags are listed separately
+// SeparateOptionalFlagsUsageTemplate is a usage template where command's optional flags are listed separately
 var SeparateOptionalFlagsUsageTemplate = `{{define "FormatCommand"}}\
 {{if .FlagSummary}} {{.FlagSummary}}{{end}}\
 {{range .Args}}{{if not .Hidden}} {{if not .Required}}[{{end}}{{if .PlaceHolder}}{{.PlaceHolder}}{{else}}<{{.Name}}>{{end}}{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}{{end}}\
@@ -169,7 +201,7 @@ Commands:
 {{end}}\
 `
 
-// Usage template with compactly formatted commands.
+// CompactUsageTemplate is a usage template with compactly formatted commands.
 var CompactUsageTemplate = `{{define "FormatCommand"}}\
 {{if .FlagSummary}} {{.FlagSummary}}{{end}}\
 {{range .Args}}{{if not .Hidden}} {{if not .Required}}[{{end}}{{if .PlaceHolder}}{{.PlaceHolder}}{{else}}<{{.Name}}>{{end}}{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}{{end}}\
@@ -217,6 +249,7 @@ Commands:
 {{end}}\
 `
 
+// ManPageTemplate renders usage in unix man format
 var ManPageTemplate = `{{define "FormatFlags"}}\
 {{range .Flags}}\
 {{if not .Hidden}}\
@@ -264,7 +297,7 @@ var ManPageTemplate = `{{define "FormatFlags"}}\
 {{end}}\
 `
 
-// Default usage template.
+// LongHelpTemplate is a usage template for --help-long
 var LongHelpTemplate = `{{define "FormatCommand"}}\
 {{if .FlagSummary}} {{.FlagSummary}}{{end}}\
 {{range .Args}}{{if not .Hidden}} {{if not .Required}}[{{end}}{{if .PlaceHolder}}{{.PlaceHolder}}{{else}}<{{.Name}}>{{end}}{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}{{end}}\

--- a/usage.go
+++ b/usage.go
@@ -210,6 +210,12 @@ func (a *Application) UsageForContextWithTemplate(context *ParseContext, indent 
 			scanner.Scan()
 			return scanner.Text()
 		},
+		"CheatCommands": func() []string {
+			return a.cheatList()
+		},
+		"Count": func(i []string) int {
+			return len(i)
+		},
 	}
 	for k, v := range a.usageFuncs {
 		funcs[k] = v


### PR DESCRIPTION
Adds Cheat() to associate cheat hints with any command
or app. When enabled the cheat command gives access to
these hints in the cheat format

At present saving to cheat not yet supported

Signed-off-by: R.I.Pienaar <rip@devco.net>