### PR TITLE
(#4) complete support for cheats

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Some historical points in time are kept:
 
 I really like [cheat](https://github.com/cheat/cheat), a great little tool that gives access to bite-sized hints on what's great about a CLI tool.
 
-Fisk supports cheats natively, you can get cheat formatted hints right from the app with no extra dependencies or export cheats into the `cheat` app for use via its interface and integrations.
+Since `v0.2.0` Fisk supports cheats natively, you can get cheat formatted hints right from the app with no extra dependencies or export cheats into the `cheat` app for use via its interface and integrations.
 
 ```nohighlight
 $ nats cheat pub
@@ -39,16 +39,28 @@ $ nats cheat pub
 nats pub destination.subject "{{ Random 100 1000 }}" -H Count:{{ Count }} --count 100
 ```
 
+Cheats are stored in a `map[string]string`, meaning it's flat, does not support subs and when saving cheats, due to the
+nature of the fluent api, 2 cheats with the same name will overwrite each other.
+
+I therefore suggest you place your cheat in the top command for an intro and then place them where you need them in the 
+first sub command only not deeper, this makes it easy to avoid clashes and easy for your users to discover them.
+
 Let's look how that is done:
 
 ```go
 // WithCheats() enables cheats without adding any to the top, you
 // can also just call Cheat() at the top to both set a cheat and enable it
 // once enabled at the top all cheats in all sub commands are accessible
-nats := fisk.New("nats", "NATS Utility").WithCheats()
+//
+// Cheats can have multiple tags, here we set the tags "middleware", and "nats"
+// that will be used when saving the cheats.  If no tags are supplied the
+// application name is used as the only tag
+nats := fisk.New("nats", "NATS Utility").WithCheats("middleware", "nats")
 
 pub := nats.Command("pub", "Publish utility")
-pub.Cheat(`# To publish 100 messages with a random.....`)
+// The cheat will be available as "pub", the if the first argument
+// is empty the name of the command will be used
+pub.Cheat("pub", `# To publish 100 messages with a random.....`)
 ```
 
 After that your app will have a new command `cheat` that gives access to the cheats. It will show
@@ -58,5 +70,8 @@ a list of cheats when trying to access a command without cheats or when running 
 $ nats cheat unknown
 Available Cheats:
 
-  nats/pub
+  pub
 ```
+
+You can save your cheats to a directory of your choice with `nats cheat --save /some/dir`, the directory
+must not already exist.

--- a/cmd.go
+++ b/cmd.go
@@ -229,7 +229,6 @@ type CmdClause struct {
 	aliases        []string
 	help           string
 	helpLong       string
-	cheat          string
 	isDefault      bool
 	validator      CmdClauseValidator
 	hidden         bool
@@ -248,9 +247,20 @@ func newCommand(app *Application, name, help string) *CmdClause {
 	return c
 }
 
-// Cheat sets the cheat text to associate with this command
-func (c *CmdClause) Cheat(cheat string) *CmdClause {
-	c.cheat = cheat
+// Cheat sets the cheat help text to associate with this command,
+// the cheat is the name it will be surfaced as in help, if empty it's the
+// name of the command.
+func (c *CmdClause) Cheat(cheat string, help string) *CmdClause {
+	if help == "" {
+		return c
+	}
+
+	if cheat == "" {
+		cheat = c.name
+	}
+
+	c.app.cheats[cheat] = help
+
 	return c
 }
 
@@ -330,27 +340,4 @@ func (c *CmdClause) Hidden() *CmdClause {
 func (c *CmdClause) HelpLong(help string) *CmdClause {
 	c.helpLong = help
 	return c
-}
-
-func (c *CmdClause) cheatCommands() (res []string) {
-	if c.cheat != "" {
-		res = append(res, c.name)
-	}
-
-	for _, sc := range c.commands {
-		if sc.name == "cheat" {
-			continue
-		}
-
-		if sc.cheat != "" {
-			res = append(res, fmt.Sprintf("%s/%s", c.name, sc.name))
-		}
-
-		if len(sc.commands) > 0 {
-			res = append(res, sc.cheatCommands()...)
-		}
-	}
-
-	return res
-
 }

--- a/model.go
+++ b/model.go
@@ -166,11 +166,11 @@ type CmdModel struct {
 	Aliases     []string
 	Help        string
 	HelpLong    string
-	Cheat       string
 	FullCommand string
 	Depth       int
 	Hidden      bool
 	Default     bool
+
 	*FlagGroupModel
 	*ArgGroupModel
 	*CmdGroupModel
@@ -181,11 +181,14 @@ func (c *CmdModel) String() string {
 }
 
 type ApplicationModel struct {
-	Name    string
-	Help    string
-	Cheat   string
-	Version string
-	Author  string
+	Name      string
+	Help      string
+	Cheat     string
+	Version   string
+	Author    string
+	Cheats    map[string]string
+	CheatTags []string
+
 	*ArgGroupModel
 	*CmdGroupModel
 	*FlagGroupModel
@@ -195,9 +198,10 @@ func (a *Application) Model() *ApplicationModel {
 	return &ApplicationModel{
 		Name:           a.Name,
 		Help:           a.Help,
-		Cheat:          a.cheat,
 		Version:        a.version,
 		Author:         a.author,
+		Cheats:         a.cheats,
+		CheatTags:      a.cheatTags,
 		FlagGroupModel: a.flagGroup.Model(),
 		ArgGroupModel:  a.argGroup.Model(),
 		CmdGroupModel:  a.cmdGroup.Model(),
@@ -265,7 +269,6 @@ func (c *CmdClause) Model() *CmdModel {
 		Aliases:        c.aliases,
 		Help:           c.help,
 		HelpLong:       c.helpLong,
-		Cheat:          c.cheat,
 		Depth:          depth,
 		Hidden:         c.hidden,
 		Default:        c.isDefault,

--- a/templates.go
+++ b/templates.go
@@ -71,38 +71,6 @@ Commands:
 {{end}}\
 `
 
-// CheatTemplate renders cheat format help for an app
-var CheatTemplate = `{{if .Context.SelectedCommand }}\
-{{if .Context.SelectedCommand.Cheat }}\
-{{ .Context.SelectedCommand.Cheat }}
-{{else}}\
-{{if gt (CheatCommands | Count) 0}}\
-Available Cheats:
-
-{{ range CheatCommands }}\
-   {{.}}
-{{end}}\
-{{else}}\
-No cheats defined
-{{end}}\
-{{end}}\
-{{else}}\
-{{ if .App.Cheat }}\
-{{.App.Cheat}}
-{{else}}\
-{{if gt (CheatCommands | Count) 0}}\
-Available Cheats:
-
-{{ range CheatCommands }}\
-   {{.}}
-{{end}}\
-{{else}}\
-No cheats defined
-{{end}}\
-{{end}}\
-{{end}}\
-`
-
 // KingpinDefaultUsageTemplate is the default usage template as used by kingpin
 var KingpinDefaultUsageTemplate = `{{define "FormatCommand"}}\
 {{if .FlagSummary}} {{.FlagSummary}}{{end}}\

--- a/usage.go
+++ b/usage.go
@@ -210,12 +210,6 @@ func (a *Application) UsageForContextWithTemplate(context *ParseContext, indent 
 			scanner.Scan()
 			return scanner.Text()
 		},
-		"CheatCommands": func() []string {
-			return a.cheatList()
-		},
-		"Count": func(i []string) int {
-			return len(i)
-		},
 	}
 	for k, v := range a.usageFuncs {
 		funcs[k] = v


### PR DESCRIPTION
This reworks the cheats somewhat after it became
impossible to save them to a directory structure
based on initial design

Cheats are now a flat map[string]string which works
a bit better and keeps things from being too complex

Saving is supported

Signed-off-by: R.I.Pienaar <rip@devco.net>