### PR TITLE
Add support for a more compact usage template

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -71,6 +71,69 @@ Commands:
 {{end}}\
 `
 
+// CompactMainUsageTemplate formats commands and subcommands in a two column
+// layout to make for a cleaners and more readable usage text. In this format,
+// sections are rendered as follows. Global flags are also separate from local
+// flags in this template. Global flags will be shown at the top level and local
+// flags will be shown when showing help for a subcommand.
+//
+// usage: <command> [<flags>] <command> [<arg> ...]
+//
+// Help text
+//
+// Commands|Subcommands:
+//   command1    Help text for command 1
+//   command2    Help text for command 2
+//   command2    Help text for command 3
+//
+// Flags:
+//   -h, --help     Show context-sensitive help
+//
+var CompactMainUsageTemplate = `{{define "FormatCommand"}}\
+{{if .FlagSummary}} {{.FlagSummary}}{{end}}\
+{{range .Args}} {{if not .Required}}[{{end}}<{{.Name}}>{{if .Value|IsCumulative}}...{{end}}{{if not .Required}}]{{end}}{{end}}\
+{{end}}\
+
+{{define "FormatUsage"}}\
+{{template "FormatCommand" .}}{{if .Commands}} <command> [<args> ...]{{end}}
+{{if .Help}}
+{{.Help|Wrap 0}}\
+{{end}}\
+{{end}}\
+
+{{if .Context.SelectedCommand}}\
+usage: {{.App.Name}} {{.Context.SelectedCommand}}{{template "FormatUsage" .Context.SelectedCommand}}
+{{if .Context.SelectedCommand.HelpLong}}{{.Context.SelectedCommand.HelpLong|Wrap 0}}
+{{end}}\
+{{else}}\
+usage: {{.App.Name}}{{template "FormatUsage" .App}}
+{{end}}\
+{{if .Context.SelectedCommand}}\
+{{if .Context.Args}}\
+Args:
+{{.Context.Args|ArgsToTwoColumns|FormatTwoColumns}}
+{{end}}\
+{{if len .Context.SelectedCommand.Commands}}\
+Subcommands:
+{{.Context.SelectedCommand.Commands|CommandsToTwoColumns|FormatTwoColumns}}
+{{end}}\
+{{else if .App.Commands}}\
+Commands:
+{{.App.Commands|CommandsToTwoColumns|FormatTwoColumns}}
+{{end}}\
+{{if .Context.SelectedCommand}}\
+{{if .Context.SelectedCommand.Flags|VisibleFlags}}\
+Flags:
+{{.Context.SelectedCommand.Flags|FlagsToTwoColumns|FormatTwoColumns}}
+{{end}}\
+{{else}}\
+{{if .Context.Flags|VisibleFlags}}\
+Global Flags:
+{{.Context.Flags|FlagsToTwoColumns|FormatTwoColumns}}
+{{end}}\
+{{end}}\
+`
+
 // KingpinDefaultUsageTemplate is the default usage template as used by kingpin
 var KingpinDefaultUsageTemplate = `{{define "FormatCommand"}}\
 {{if .FlagSummary}} {{.FlagSummary}}{{end}}\

--- a/usage.go
+++ b/usage.go
@@ -177,6 +177,16 @@ func (a *Application) UsageForContextWithTemplate(context *ParseContext, indent 
 			}
 			return optionalFlags
 		},
+		"CommandsToTwoColumns": func(c []*CmdModel) [][2]string {
+			rows := [][2]string{}
+			for _, cmd := range c {
+				if !cmd.Hidden && cmd.FullCommand != "help" {
+					shortHelp := strings.Split(cmd.Help, "\n")[0]
+					rows = append(rows, [2]string{cmd.FullCommand, shortHelp})
+				}
+			}
+			return rows
+		},
 		"ArgsToTwoColumns": func(a []*ArgModel) [][2]string {
 			rows := [][2]string{}
 			for _, arg := range a {


### PR DESCRIPTION
This PR adds support for a more compact usage template for top-level, sub commands and subcommand/known command errors.

To not break any current projects that use this package, I added and `ErrorUsageTemplate` method on Application to support customizing the usage template for subcommand related errors.

I also split up global vs local flags in this template to clean up the output a bit.

This is to support https://github.com/nats-io/natscli/pull/523

Example - Top Level NATS command: 
```bash
 nats
usage: nats [<flags>] <command> [<args> ...]

NATS Utility

NATS Server and JetStream administration.

See 'nats cheat' for a quick cheatsheet of commands

Commands:
  account    Account information and status
  backup     JetStream configuration backup utility
  bench      Benchmark utility
  consumer   JetStream Consumer management
  context    Manage nats configuration contexts
  errors     Error code documentation
  events     Show Advisories and Events
  governor   Controls the concurrency of distributed command executions
  kv         Interacts with a JetStream based Key-Value store
  latency    Perform latency tests between two NATS servers
  object     Interacts with a JetStream based Object store
  publish    Generic data publish utility
  request    Generic request-reply request utility
  reply      Generic service reply utility
  restore    Restores a backup of JetStream configuration
  rtt        Compute round-trip time to NATS server
  schema     Schema tools
  server     Server information
  stream     JetStream Stream management
  subscribe  Generic subscription client

Global Flags:
  -h, --help                    Show context-sensitive help
      --version                 Show application version.
  -s, --server=URL              NATS server urls ($NATS_URL)
      --user=USER               Username or Token ($NATS_USER)
      --password=PASSWORD       Password ($NATS_PASSWORD)
      --connection-name=NAME    Nickname to use for the underlying NATS Connection
      --creds=FILE              User credentials ($NATS_CREDS)
      --nkey=FILE               User NKEY ($NATS_NKEY)
      --tlscert=FILE            TLS public certificate ($NATS_CERT)
      --tlskey=FILE             TLS private key ($NATS_KEY)
      --tlsca=FILE              TLS certificate authority chain ($NATS_CA)
      --timeout=DURATION        Time to wait on responses from NATS ($NATS_TIMEOUT)
      --js-api-prefix=PREFIX    Subject prefix for access to JetStream API
      --js-event-prefix=PREFIX  Subject prefix for access to JetStream Advisories
      --js-domain=DOMAIN        JetStream domain to access
      --inbox-prefix=PREFIX     Custom inbox prefix to use for inboxes
      --context=NAME            Configuration context ($NATS_CONTEXT)
      --trace                   Trace API interactions
```

And a subcommand:
```bash
 nats stream
error: a subcommand from the list below is required, use --help for full help including flags and arguments

usage: nats stream [<flags>] <command> [<args> ...]

JetStream Stream management

Subcommands:
  stream ls        List all known Streams
  stream report    Reports on Stream statistics
  stream find      Finds streams matching certain criteria
  stream info      Stream information
  stream add       Create a new Stream
  stream edit      Edits an existing stream
  stream rm        Removes a Stream
  stream purge     Purge a Stream without deleting it
  stream copy      Creates a new Stream based on the configuration of another
  stream rmm       Securely removes an individual message from a Stream
  stream view      View messages in a stream
  stream get       Retrieves a specific message from a Stream
  stream backup    Creates a backup of a Stream over the NATS network
  stream restore   Restore a Stream over the NATS network
  stream seal      Seals a stream preventing further updates
  stream cluster   Manages a clustered Stream
  stream template  Manages Stream Templates

Flags:
  -a, --all  When listing or selecting streams show all streams including system ones
```

And a command with a lot of local flags:

```bash
 nats help stream add
usage: nats stream add [<flags>] [<stream>]

Create a new Stream

Args:
  [<stream>]  Stream name

Flags:
      --config=CONFIG            JSON file to read configuration from
      --validate                 Only validates the configuration against the official Schema
      --output=FILE              Save configuration instead of creating
      --subjects=SUBJECTS ...    Subjects that are consumed by the Stream
      --description=DESCRIPTION  Sets a contextual description for the stream
      --storage=STORAGE          Storage backend to use (file, memory)
      --replicas=REPLICAS        When clustered, how many replicas of the data to create
      --tag=TAG ...              Place the stream on servers that has specific tags (pass multiple times)
      --cluster=CLUSTER          Place the stream on a specific cluster
      --[no-]ack                 Acknowledge publishes
      --retention=RETENTION      Defines a retention policy (limits, interest, work)
      --discard=DISCARD          Defines the discard policy (new, old)
      --max-age=""               Maximum age of messages to keep
      --max-bytes=MAX-BYTES      Maximum bytes to keep
      --max-consumers=-1         Maximum number of consumers to allow
      --max-msg-size=MAX-MSG-SIZE  
                                 Maximum size any 1 message may be
      --max-msgs=0               Maximum amount of messages to keep
      --max-msgs-per-subject=0   Maximum amount of messages to keep per subject
      --dupe-window=""           Duration of the duplicate message tracking window
      --mirror=MIRROR            Completely mirror another stream
      --source=STREAM ...        Source data from other Streams, merging into this one
      --[no-]allow-rollup        Allows roll-ups to be done by publishing messages with special headers
      --[no-]deny-delete         Deny messages from being deleted via the API
      --[no-]deny-purge          Deny entire stream or subject purges via the API
      --[no-]allow-direct        Allows fast, direct, access to stream data via the direct get API
  -j, --json                     Produce JSON output
      --republish-source=REPUBLISH-SOURCE  
                                 Republish messages to --republish-destination
      --republish-destination=REPUBLISH-DESTINATION  
                                 Republish destination for messages in --republish-source
      --republish-headers        Republish only message headers, no bodies
```