### PR TITLE
An attempt to make completion work better in conjunction with default commands.

### DIFF
--- a/app.go
+++ b/app.go
@@ -243,7 +243,6 @@ func (a *Application) Parse(args []string) (command string, err error) {
 	if err = a.applyPreActions(context, !a.completion); err != nil {
 		return "", err
 	}
-
 	if a.completion {
 		a.generateBashCompletion(context)
 		a.terminate(0)
@@ -934,7 +933,19 @@ func (a *Application) completionOptions(context *ParseContext) []string {
 
 func (a *Application) generateBashCompletion(context *ParseContext) {
 	options := a.completionOptions(context)
-	fmt.Printf("%s", strings.Join(options, "\n"))
+	opt1String := strings.Join(options, "\n")
+
+	// Re-parse the command-line ignoring defaults to find what if we did not set defaults
+	context, _ = a.parseContext(true, context.rawArgs)
+	opt2String := strings.Join(a.completionOptions(context), "\n")
+	if opt1String == "" {
+		fmt.Printf("%s", opt2String)
+	} else if opt2String != opt1String {
+		fmt.Printf("%s\n%s", opt1String, opt2String)
+	} else {
+		fmt.Printf("%s", opt1String)
+	}
+
 }
 
 func envarTransform(name string) string {


### PR DESCRIPTION
We are pleased to use 'fisk' for our tooling. There is just one problem for us: When you have a command set as `Default()`, the completion (we use bash) works in a way, that makes it a bit pointless because it considers only arguments following the default. I tried different things to fix that. In the end came to the solution to calculate the options with and without the defaults and then, when they differ, return the combination of them. This way, it seems, we can have a meaningful output while still using default commands. From my tests, it also works with multiple default commands (see our newest [msgcvt](https://github.com/metatexx/msgcvt) (for `nats --translate`).

P.S.: I think there are no repeating flags in commands allowed (which bothers me a bit). So it should be enough to compare the final strings. If not, one would need to work on the single options and filter out duplicates.