### PR TITLE
A try to make completion work better with default commands.

### DIFF
--- a/app.go
+++ b/app.go
@@ -934,7 +934,19 @@ func (a *Application) completionOptions(context *ParseContext) []string {
 
 func (a *Application) generateBashCompletion(context *ParseContext) {
 	options := a.completionOptions(context)
-	fmt.Printf("%s", strings.Join(options, "\n"))
+	opt1String := strings.Join(options, "\n")
+
+	// Re-parse the command-line ignoring defaults to find what if we did not set defaults
+	context, _ = a.parseContext(true, context.rawArgs)
+	opt2String := strings.Join(a.completionOptions(context), "\n")
+	if opt1String == "" {
+		fmt.Printf("%s", opt2String)
+	} else if opt2String != opt1String {
+		fmt.Printf("%s\n%s", opt1String, opt2String)
+	} else {
+		fmt.Printf("%s", opt1String)
+	}
+
 }
 
 func envarTransform(name string) string {


### PR DESCRIPTION
We are pleased to use 'fisk' for our tooling. There is just one problem for us: When you have a command set as Default(), the completion (we use bash) works in a way, that makes it a bit pointless because it considers only arguments following the default. 

I tried different things to fix that. In the end came to the solution to calculate the options with and without the defaults and then, when they differ, return the combination of them. This way, it seems, we can have a meaningful output while still using default commands. From my tests, it also works with multiple default commands (see our newest [msgcvt](https://github.com/metatexx/msgcvt) (a tool for `nats --translate`).

Revived from #39