### PR TITLE
Do not pass command name to --completion-bash argument in ZSH template

### DIFF
--- a/templates.go
+++ b/templates.go
@@ -387,7 +387,7 @@ complete -F _{{.App.Name}}_bash_autocomplete -o default {{.App.Name}}
 var ZshCompletionTemplate = `#compdef {{.App.Name}}
 
 _{{.App.Name}}() {
-    local matches=($(${words[1]} --completion-bash "${(@)words[1,$CURRENT]}"))
+    local matches=($(${words[1]} --completion-bash "${(@)words[2,$CURRENT]}"))
     compadd -a matches
 
     if [[ $compstate[nmatches] -eq 0 && $words[$CURRENT] != -* ]]; then


### PR DESCRIPTION
See https://github.com/alecthomas/kingpin/pull/339

> [!NOTE]
> I will add a PR to [natscli](https://github.com/nats-io/natscli) to add the man page and zsh completion in Brew Formula via GoReleaser.

**Before:**
<img width="1624" alt="before" src="https://github.com/user-attachments/assets/7647efa3-8ee3-41c9-baa9-6f1e03c17a5c" />

**After:**
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/28c175b9-cfd7-4fd4-8c6b-f9d645587c42" />
