### PR TITLE
show default value for bool flags in help text

### DIFF
--- a/model.go
+++ b/model.go
@@ -116,10 +116,17 @@ func (f *FlagModel) FormatPlaceHolder() string {
 }
 
 func (f *FlagModel) HelpWithEnvar() string {
-	if f.Envar == "" {
-		return f.Help
+	help := f.Help
+	
+	// Add default value for boolean flags
+	if f.IsBoolFlag() && len(f.Default) > 0 {
+		help = fmt.Sprintf("%s (default: %s)", help, f.Default[0])
 	}
-	return fmt.Sprintf("%s ($%s)", f.Help, f.Envar)
+	
+	if f.Envar == "" {
+		return help
+	}
+	return fmt.Sprintf("%s ($%s)", help, f.Envar)
 }
 
 type ArgGroupModel struct {


### PR DESCRIPTION
Not all users:
1) want to think 
2) familiar with the convention about `--[no]-flag` means  "is on by default".

Having that it is possible to have `BoolVar` with default set to `false`, I think we want to do something to make it crystal clear. 

If we add a default to help text, it is a non-breaking change and a clear improvement.
Here is what it will look like in natscli:
 
https://gist.github.com/alexbozhenko/2f46475b9f7c37f6932f5603bcb502e6
